### PR TITLE
Setup pre-commit.sh and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ We welcome contributions to improve the pre-commit hooks. Feel free to submit is
 
 ## License
 
-This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache 2.0 License - see the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # cairo-pre-commit
-This repository will include everything that a Cairo project needs to utilize pre-commit hooks.
+
+## Introduction
+
+This repository hosts pre-commit hooks for Cairo (StarkNet programming language) projects. Pre-commit hooks help maintain code quality by automatically running specified tasks such as formatting code, running tests, and checking documentation formatting before a commit is made.
+
+## Dependencies
+
+- [`scarb`](https://docs.swmansion.com/scarb/download.html): Cairo's build tool for formatting and testing.
+- [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm): A package manager for JavaScript, which comes bundled with Node.js.
+- `Prettier`: An opinionated code formatter. Install globally using the following command:
+  ```bash
+  npm install --global prettier
+  ```
+
+## Installation
+
+1. Clone or download this repository to your local machine.
+2. Make the pre-commit script executable by running the following command:
+   ```bash
+   chmod +x pre-commit.sh
+   ```
+
+## Configuration
+
+1. Navigate to your Cairo project repository on your local machine.
+2. Go to the `.git/hooks` directory.
+3. Create a file named `pre-commit` (without any file extension).
+4. Inside the `pre-commit` file, add the following line to execute the `pre-commit.sh` script:
+   ```bash
+   exec /path/to/pre-commit.sh
+   ```
+
+## Usage
+
+The pre-commit hooks will automatically run the following commands when a commit is attempted:
+
+- `scarb fmt`: Formats the Cairo code.
+- `scarb test`: Runs tests in the Cairo project.
+- `npx prettier --check README.md`: Checks the formatting of the README file.
+
+## Troubleshooting
+
+If you encounter any issues while setting up or using the pre-commit hooks, check the following:
+
+- Ensure that `scarb`, `npm`, and `Prettier` are installed and accessible from the command line.
+- Verify that the `pre-commit` file is correctly set up in the `.git/hooks` directory and that the path to `pre-commit.sh` is correct.
+
+## Contributing
+
+We welcome contributions to improve the pre-commit hooks. Feel free to submit issues, propose new features, or create pull requests.
+
+## License
+
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details.

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Function to run scarb fmt
+function run_scarb_fmt {
+    echo "Running scarb fmt..."
+    scarb fmt
+    if [[ $? -ne 0 ]]; then
+        echo "scarb fmt failed, aborting commit."
+        exit 1
+    fi
+}
+
+# Function to run scarb test
+function run_scarb_test {
+    echo "Running scarb test..."
+    scarb test
+    if [[ $? -ne 0 ]]; then
+        echo "scarb test failed, aborting commit."
+        exit 1
+    fi
+}
+
+# Function to run npx prettier --check on README
+function run_prettier_check {
+    echo "Running npx prettier --check on README..."
+    npx prettier --check README.md
+    if [[ $? -ne 0 ]]; then
+        echo "Prettier check failed, aborting commit."
+        exit 1
+    fi
+}
+
+# Execute the functions
+run_scarb_fmt
+run_scarb_test
+run_prettier_check


### PR DESCRIPTION
Fixes #1 - Cairo, unlike Rust, isn't supported by [pre-commit](https://pre-commit.com/#supported-languages) and the supported prettier appears to use npm, so i've also included that in the bash script.

The setup process should be made clear by the README.